### PR TITLE
修复路由缓存BUG

### DIFF
--- a/src/store/modules/d2admin/modules/permission.js
+++ b/src/store/modules/d2admin/modules/permission.js
@@ -101,7 +101,8 @@ export default context => {
           name: sourceItem.route_name,
           meta: {
             title: sourceItem.menu_name,
-            auth: true
+            auth: true,
+            cache: sourceItem.route_cache === context.env.VUE_APP_DICT_IS_TRUE
           },
           component: utils.import(sourceItem.route_component)
         }


### PR DESCRIPTION
[BUG | 设置菜单缓存为true，前端并未进入keepAlive](https://github.com/d2-projects/d2-admin-xiya-go-cms/issues/21#issue-607229362)